### PR TITLE
Some simple changes to make commit.py more readable

### DIFF
--- a/commit.py
+++ b/commit.py
@@ -54,25 +54,27 @@ class Commit:
 
 	@staticmethod
 	def cleanUpCommitMessage(msg):
-		msg = re.sub(re_gitsvn, '', msg)
+        msg = re_gitsvn.sub('', msg)
 		return msg.strip()
 
 	def getBasePath(self):
 		if not self.initialized:
 			raise Exception("called getBasePath on unitialized Commit object")
 			
-		if len(self.files) == 0: return ""
+		if not self.files: return ""
+
 		trunks = [p for p in self.files if "/trunk" in p]
 		branches = [p for p in self.files if "/branches" in p]
 		tags = [p for p in self.files if "/tags" in p]
 		odd = [p for p in self.files if p not in trunks and p not in branches and p not in tags]
-		if ((1 if len(trunks) > 0 else 0) + (1 if len(branches) > 0 else 0) + \
-				(1 if len(tags) > 0 else 0) + (1 if len(odd) > 0 else 0)) > 1:
+
+		if ((1 if trunks else 0) + (1 if branches else 0) + \
+				(1 if tags else 0) + (1 if odd else 0)) > 1:
 				ret = []
-				if len(trunks) > 0: ret.append(os.path.commonprefix(trunks))
-				if len(branches) > 0: ret.append(os.path.commonprefix(branches))
-				if len(tags) > 0: ret.append(os.path.commonprefix(tags))
-				if len(odd) > 0: ret.append(os.path.commonprefix(odd))
+				if trunks: ret.append(os.path.commonprefix(trunks))
+				if branches: ret.append(os.path.commonprefix(branches))
+				if tags: ret.append(os.path.commonprefix(tags))
+				if odd: ret.append(os.path.commonprefix(odd))
 				return ret
 		else:
 				return os.path.dirname(os.path.commonprefix(self.files))
@@ -111,14 +113,14 @@ class Commit:
 
 		self.commitid = conn.insert_id()
 
-		if len(self.files):
+		if self.files:
 			sql = "INSERT INTO " + DB.commitfile._table + "(commitid, file) "
 			for f in self.files:
 				sql += "SELECT " + str(self.commitid) + ", %s UNION "
 			sql = sql[:-6]
 			c.execute(sql, self.files)
 		
-		if(len(self.dbkeywords)):
+		if self.dbkeywords:
 			sql = "INSERT INTO " + DB.commitkeyword._table + "(commitid, keyword) "
 			for f in self.dbkeywords:
 				sql += "SELECT " + str(self.commitid) + ", %s UNION "
@@ -136,18 +138,17 @@ class Commit:
 		s += "ID:\t\t %s%s" % (self.uniqueid, eol)
 		s += "Date:\t\t %s (%s)%s" % (unixToGitDateFormat(self.date), self.date, eol)
 		s += "Log Message:\t %s%s" % (self.message, eol)
-		if len(self.files) > 0:
+		if self.files:
 			s += "Files:\t\t %s%s" % (self.files[0], eol)
 			for p in self.files[1:]:
 				s += "\t\t %s%s" % (p, eol)
 
-		if len(self.base_paths) > 0:
-			if len(self.base_paths) > 0 and not isinstance(self.base_paths, basestring):
-				s += "Base Paths:\t %s%s" % (self.base_paths[0], eol)
-				for p in self.base_paths[1:]:
-					s += "\t\t %s%s" % (p, eol)
-				else:
-					s += "Base Path:\t %s%s" % (self.base_paths, eol)
+		if self.base_paths and not isinstance(self.base_paths, basestring):
+            s += "Base Paths:\t %s%s" % (self.base_paths[0], eol)
+            for p in self.base_paths[1:]:
+                s += "\t\t %s%s" % (p, eol)
+            else:
+                s += "Base Path:\t %s%s" % (self.base_paths, eol)
 		s+= "Keywords:\t %s%s" % (", ".join(self.keywords), eol)
 		return s
 	

--- a/common.py
+++ b/common.py
@@ -1,8 +1,6 @@
 #!/usr/bin/python
 
-import time,os,urlparse,re, datetime
-
-import synonymmapping
+import time, os, urlparse, re, datetime, synonymmapping
 
 def fla(a, b):
 	if a and not b:
@@ -14,8 +12,7 @@ def fla(a, b):
 		return a
 
 def unixToGitDateFormat(t):
-	s = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(t))
-	return s
+	return time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(t))
 
 def unixToDatetime(t):
 	return datetime.datetime.utcfromtimestamp(t)
@@ -34,11 +31,11 @@ def fixDates(start, end):
 		print "Invalid Start or End Date"
 		exit
 		
-	if end == 0 and start < 0:
+	if start and not end:
 		end = time.time()
 		start = end + int(start)
 	elif end < start:
-		tmp = end
-		end = start
-		start = tmp
+		end += start
+		start = end - start
+		end = end - start
 	return start, end


### PR DESCRIPTION
First, if you're only using a compiled regular expression once, at least use
it completely. Every compiled regular expression in python allows you to call
the re functions on it passing one less argument.

Second, if you find yourself constantly checking to make sure the length of an
object is greater than 0, you're doing it wrong. In python a non-empty object (a
list, dictionary, tuple, or string that is not [], {}, () or '' respectively) is
'True' or > 0 and an empty object is 0 or 'False'. This simplifies the code
greatly.

In reality, lines 71-80 could probably be simplified, but it isn't exactly
important.
