### PR TITLE
Regular Expression Matching

### DIFF
--- a/commit.py
+++ b/commit.py
@@ -91,14 +91,18 @@ class Commit:
 
 		keywords = set()
 		for k in synonymmapping.getMap():
-			lk = " " + k + " "
-			pk = "/" + k
+			#lk = " " + k + " "
+			#pk = "/" + k
+			ls = re.compile('\w*\s*' + k + '\s*\w*')
+			pk = re.compile('/\w*' + k + '\w*')
 			
-			if lk in log:
+			#if lk in log:
+			if lk.search(log):
 				keywords.add(k)
 				for v in synonymmapping.map[k]: keywords.add(v)
 			for p in paths:
-				if pk in p:
+				#if pk in p:
+				if pk.search(p):
 					keywords.add(k)
 					for v in synonymmapping.map[k]: keywords.add(v)
 


### PR DESCRIPTION
This should close issue #7. I double checked the patterns on the python command line.
```> import re

> re.search('\w_\s_tor\w_\s_', 'Happy tor Birthday') # Can be repeated with other examples
> <_sre.SRE_Match object at ... >
> re.search('/\w_tor\w_', '/prepfortornado') # Also works with '/torbob'
> <_sre.SRE_Match object at ... >```

And one overarching pattern could be used like
`r'/?\w*\s*tor\w*\s*'` and would allow for spaces in directory names, if one so desired. (Would be cheaper in terms of only one compilation for both expressions)
